### PR TITLE
Virtual Z Levels

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -104,7 +104,7 @@ Actual Adjacent procs :
 	if(!start || !end)
 		stack_trace("Invalid A* start or destination")
 		return FALSE
-	if( start.z != end.z || start == end ) //no pathfinding between z levels
+	if( start.get_virtual_z_level() != end.get_virtual_z_level() || start == end ) //no pathfinding between z levels
 		return FALSE
 	if(maxnodes)
 		//if start turf is farther than maxnodes from end turf, no need to do anything

--- a/code/__HELPERS/virtual_z_level.dm
+++ b/code/__HELPERS/virtual_z_level.dm
@@ -1,0 +1,16 @@
+
+/**
+  * Gets a unique value for a new virtual z level.
+  */
+/proc/get_new_virtual_z()
+	var/static/virtual_value = 1000
+	return virtual_value ++
+
+/**
+  * Used to get the virtual z-level.
+  * Will give unique values to each shuttle while it is in a transit level.
+  * Note: If the user teleports to another virtual z on the same z-level they will need to have reset_virtual_z called. (Teleportations etc.)
+  */
+/atom/proc/get_virtual_z_level()
+	var/area/A = get_area(src)
+	return A.get_virtual_z()

--- a/code/__HELPERS/virtual_z_level.dm
+++ b/code/__HELPERS/virtual_z_level.dm
@@ -1,6 +1,7 @@
 
 /**
   * Gets a unique value for a new virtual z level.
+  * This is just a number, the game wont slow down if you have a ton of empty ones.
   */
 /proc/get_new_virtual_z()
 	var/static/virtual_value = 1000

--- a/code/__HELPERS/virtual_z_level.dm
+++ b/code/__HELPERS/virtual_z_level.dm
@@ -13,5 +13,9 @@
   * Note: If the user teleports to another virtual z on the same z-level they will need to have reset_virtual_z called. (Teleportations etc.)
   */
 /atom/proc/get_virtual_z_level()
+	var/datum/turf_reservation/TR = SSmapping.get_turf_reservation_at_coords(x, y, z) //Try to see if the atom is in a turf reservation, and if so, return it's virtual z level
+	if(TR)
+		return TR.virtual_z_level
+
 	var/area/A = get_area(src)
 	return A.get_virtual_z()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -457,7 +457,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return
 	var/turf/P = get_turf(blood_target)
 	var/turf/Q = get_turf(owner)
-	if(!P || !Q || (P.z != Q.z)) //The target is on a different Z level, we cannot sense that far.
+	if(!P || !Q || (P.get_virtual_z_level()!= Q.get_virtual_z_level())) //The target is on a different Z level, we cannot sense that far.
 		icon_state = "runed_sense2"
 		desc = "You can no longer sense your target's presence."
 		return

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -214,7 +214,7 @@ SUBSYSTEM_DEF(explosions)
 
 	var/x0 = epicenter.x
 	var/y0 = epicenter.y
-	var/z0 = epicenter.z
+	var/z0 = epicenter.get_virtual_z_level()
 	var/area/areatype = get_area(epicenter)
 	SSblackbox.record_feedback("associative", "explosion", 1, list("dev" = devastation_range, "heavy" = heavy_impact_range, "light" = light_impact_range, "flash" = flash_range, "flame" = flame_range, "orig_dev" = orig_dev_range, "orig_heavy" = orig_heavy_range, "orig_light" = orig_light_range, "x" = x0, "y" = y0, "z" = z0, "area" = areatype.type, "time" = time_stamp("YYYY-MM-DD hh:mm:ss", 1)))
 
@@ -245,7 +245,7 @@ SUBSYSTEM_DEF(explosions)
 			var/mob/M = MN
 			// Double check for client
 			var/turf/M_turf = get_turf(M)
-			if(M_turf && M_turf.z == z0)
+			if(M_turf && M_turf.get_virtual_z_level() == z0)
 				var/dist = get_dist(M_turf, epicenter)
 				var/baseshakeamount
 				if(orig_max_distance - dist > 0)

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -318,7 +318,9 @@ SUBSYSTEM_DEF(explosions)
 		var/flame_dist = dist < flame_range
 		var/throw_dist = dist
 
-		if(dist < devastation_range)
+		if(T.get_virtual_z_level() != z0)
+			dist = EXPLODE_NONE
+		else if(dist < devastation_range)
 			dist = EXPLODE_DEVASTATE
 		else if(dist < heavy_impact_range)
 			dist = EXPLODE_HEAVY

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -636,3 +636,13 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		LM.load()
 	if(GLOB.stationroom_landmarks.len)
 		seedStation() //I'm sure we can trust everyone not to insert a 1x1 rooms which loads a landmark which loads a landmark which loads a la...
+
+/datum/controller/subsystem/mapping/proc/get_turf_reservation_at_coords(x, y, z)
+	for(var/datum/turf_reservation/TR as anything() in turf_reservations)
+		if(z < TR.bottom_left_coords[3] || z > TR.top_right_coords[3])
+			continue
+		if(x < TR.bottom_left_coords[1] || x > TR.top_right_coords[1])
+			continue
+		if(y < TR.bottom_left_coords[2] || y > TR.top_right_coords[2])
+			continue
+		return TR

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -638,7 +638,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		seedStation() //I'm sure we can trust everyone not to insert a 1x1 rooms which loads a landmark which loads a landmark which loads a la...
 
 /datum/controller/subsystem/mapping/proc/get_turf_reservation_at_coords(x, y, z)
-	for(var/datum/turf_reservation/TR as anything() in turf_reservations)
+	for(var/datum/turf_reservation/TR as anything in turf_reservations)
 		if(z < TR.bottom_left_coords[3] || z > TR.top_right_coords[3])
 			continue
 		if(x < TR.bottom_left_coords[1] || x > TR.top_right_coords[1])

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -47,7 +47,7 @@
 		return
 	recalculating = TRUE
 	timing_id = null
-	if(origin && target && get_dist(origin,target)<max_distance && origin.z == target.z)
+	if(origin && target && get_dist(origin,target)<max_distance && origin.get_virtual_z_level() == target.get_virtual_z_level())
 		var/origin_turf = get_turf(origin)
 		var/target_turf = get_turf(target)
 		if(!static_beam && (origin_turf != origin_oldloc || target_turf != target_oldloc))

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -119,12 +119,12 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		if(G.emped || !G.tracking || G == src)
 			continue
 		var/turf/pos = get_turf(G.parent)
-		if(!pos || !global_mode && pos.z != curr.z)
+		if(!pos || !global_mode && pos.get_virtual_z_level() != curr.get_virtual_z_level())
 			continue
 		var/list/signal = list()
 		signal["entrytag"] = G.gpstag //Name or 'tag' of the GPS
-		signal["coords"] = "[pos.x], [pos.y], [pos.z]"
-		if(pos.z == curr.z) //Distance/Direction calculations for same z-level only
+		signal["coords"] = "[pos.x], [pos.y], [pos.get_virtual_z_level()]"
+		if(pos.get_virtual_z_level() == curr.get_virtual_z_level()) //Distance/Direction calculations for same z-level only
 			signal["dist"] = max(get_dist(curr, pos), 0) //Distance between the src and remote GPS turfs
 			signal["degrees"] = round(Get_Angle(curr, pos)) //0-360 degree directional bearing, for more precision.
 		signals += list(signal) //Add this signal to the list of signals

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 	var/turf/curr = get_turf(parent)
 	data["currentArea"] = "[get_area_name(curr, TRUE)]"
-	data["currentCoords"] = "[curr.x], [curr.y], [curr.z]"
+	data["currentCoords"] = "[curr.x], [curr.y], [curr.get_virtual_z_level()]"
 
 	var/list/signals = list()
 	data["signals"] = list()

--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -9,7 +9,7 @@
 		var/atom/dumping_location = dest.get_dumping_location()
 		var/turf/bagT = get_turf(parent)
 		var/turf/destT = get_turf(dumping_location)
-		if(destT && bagT && bagT.z == destT.z && get_dist(M, dumping_location) < dumping_range)
+		if(destT && bagT && bagT.get_virtual_z_level() == destT.get_virtual_z_level() && get_dist(M, dumping_location) < dumping_range)
 			if(dumping_location.storage_contents_dump_act(src, M))
 				if(alt_sound && prob(1))
 					playsound(src, alt_sound, 40, TRUE)

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -95,7 +95,7 @@ STI KALY - blind
 
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(T.z != affected_mob.z)
+		if(T.get_virtual_z_level() != affected_mob.get_virtual_z_level())
 			continue
 		if(T.name == "space")
 			continue

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -85,10 +85,10 @@
 	if(tracking_target == user)
 		to_chat(user,"<span class='warning'>You smell out the trail to yourself. Yep, it's you.</span>")
 		return
-	if(usr.z < tracking_target.z)
+	if(usr.get_virtual_z_level() < tracking_target.get_virtual_z_level())
 		to_chat(user,"<span class='warning'>The trail leads... way up above you? Huh. They must be really, really far away.</span>")
 		return
-	else if(usr.z > tracking_target.z)
+	else if(usr.get_virtual_z_level() > tracking_target.get_virtual_z_level())
 		to_chat(user,"<span class='warning'>The trail leads... way down below you? Huh. They must be really, really far away.</span>")
 		return
 	var/direction_text = "[dir2text(get_dir(usr, tracking_target))]"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -665,3 +665,10 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /// A hook so areas can modify the incoming args (of what??)
 /area/proc/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
 	return flags
+
+/// Gets an areas virtual z value. For having multiple areas on the same z-level treated mechanically as different z-levels
+/area/proc/get_virtual_z()
+	return z
+
+/area/get_virtual_z_level()
+	return get_virtual_z()

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -16,7 +16,13 @@
 	lighting_colour_bulb = "#ffe1c1"
 	area_limited_icon_smoothing = TRUE
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	//The mobile port attached to this area
+	var/obj/docking_port/mobile/mobile_port
 
+
+/area/shuttle/Destroy()
+	mobile_port = null
+	. = ..()
 
 /area/shuttle/PlaceOnTopReact(list/new_baseturfs, turf/fake_turf_type, flags)
 	. = ..()
@@ -24,6 +30,14 @@
 		return // More complicated larger changes indicate this isn't a player
 	if(ispath(new_baseturfs[1], /turf/open/floor/plating) && !new_baseturfs.Find(/turf/baseturf_skipover/shuttle))
 		new_baseturfs.Insert(1, /turf/baseturf_skipover/shuttle)
+
+/area/shuttle/proc/link_to_shuttle(obj/docking_port/mobile/M)
+	mobile_port = M
+
+/area/shuttle/get_virtual_z()
+	if(mobile_port)
+		return mobile_port.virtual_z
+	return ..()
 
 ////////////////////////////Multi-area shuttles////////////////////////////
 

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -36,7 +36,7 @@
 
 /area/shuttle/get_virtual_z()
 	if(mobile_port)
-		return mobile_port.virtual_z
+		return mobile_port.get_virtual_z_level()
 	return ..()
 
 ////////////////////////////Multi-area shuttles////////////////////////////

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1469,9 +1469,9 @@
 		return A.has_gravity
 	else
 		// There's a gravity generator on our z level
-		if(GLOB.gravity_generators["[T.z]"])
+		if(GLOB.gravity_generators["[T.get_virtual_z_level()]"])
 			var/max_grav = 0
-			for(var/obj/machinery/gravity_generator/main/G in GLOB.gravity_generators["[T.z]"])
+			for(var/obj/machinery/gravity_generator/main/G in GLOB.gravity_generators["[T.get_virtual_z_level()]"])
 				max_grav = max(G.setting,max_grav)
 			return max_grav
 	return SSmapping.level_trait(T.z, ZTRAIT_GRAVITY)

--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 				var/turf/end_point = get_turf(device)
 				if(!end_point)
 					continue
-				if(start_point.z != end_point.z || (range > 0 && get_dist(start_point, end_point) > range))
+				if(start_point.get_virtual_z_level() != end_point.get_virtual_z_level() || (range > 0 && get_dist(start_point, end_point) > range))
 					continue
 			device.receive_signal(signal)
 

--- a/code/game/gamemodes/clown_ops/bananium_bomb.dm
+++ b/code/game/gamemodes/clown_ops/bananium_bomb.dm
@@ -32,7 +32,7 @@
 	for(var/i in GLOB.human_list)
 		var/mob/living/carbon/human/H = i
 		var/turf/T = get_turf(H)
-		if(!T || T.z != z)
+		if(!T || T.get_virtual_z_level() != get_virtual_z_level())
 			continue
 		H.Stun(10)
 		var/obj/item/clothing/C

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 			if((M.orbiting) && (SSaugury.watchers[M]))
 				continue
 			var/turf/T = get_turf(M)
-			if(!T || T.z != src.z)
+			if(!T || T.get_virtual_z_level() != src.get_virtual_z_level())
 				continue
 			var/dist = get_dist(M.loc, src.loc)
 			shake_camera(M, dist > 20 ? 2 : 4, dist > 20 ? 1 : 3)

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -37,7 +37,7 @@
 	..()
 
 /obj/machinery/computer/apc_control/proc/check_apc(obj/machinery/power/apc/APC)
-	return APC.z == z && !APC.malfhack && !APC.aidisabled && !(APC.obj_flags & EMAGGED) && !APC.machine_stat && !istype(APC.area, /area/ai_monitored) && !APC.area.outdoors
+	return APC.get_virtual_z_level() == get_virtual_z_level() && !APC.malfhack && !APC.aidisabled && !(APC.obj_flags & EMAGGED) && !APC.machine_stat && !istype(APC.area, /area/ai_monitored) && !APC.area.outdoors
 
 /obj/machinery/computer/apc_control/ui_interact(mob/user, datum/tgui/ui)
 	operator = user

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -167,7 +167,7 @@
 /obj/machinery/computer/security/proc/get_available_cameras()
 	var/list/L = list()
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
-		if((is_away_level(z) || is_away_level(C.z)) && (C.z != z))//if on away mission, can only receive feed from same z_level cameras
+		if((is_away_level(z) || is_away_level(C.z)) && (C.get_virtual_z_level() != get_virtual_z_level()))//if on away mission, can only receive feed from same z_level cameras
 			continue
 		L.Add(C)
 	var/list/D = list()

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -93,10 +93,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	return ui_sources[user]
 
 /datum/crewmonitor/ui_data(mob/user)
-	var/z = user.z
+	var/z = user.get_virtual_z_level()
 	if(!z)
 		var/turf/T = get_turf(user)
-		z = T.z
+		z = T.get_virtual_z_level()
 	var/list/zdata = update_data(z, SSmapping.level_trait(z, ZTRAIT_STATION))
 	. = list()
 	.["sensors"] = zdata
@@ -130,7 +130,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Check if their z-level is correct and if they are wearing a uniform.
 		// Accept H.z==0 as well in case the mob is inside an object.
 		// Accept any station zlevel if the console user is on a station zlevel
-		if ((H.z == 0 || H.z == z || (station && SSmapping.level_trait(H.z, ZTRAIT_STATION))) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
+		if ((H.z == 0 || H.get_virtual_z_level() == z || (station && SSmapping.level_trait(H.z, ZTRAIT_STATION))) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
 			U = H.w_uniform
 
 			// Are the suit sensors on?
@@ -138,7 +138,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				pos = H.z == 0 || (nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
 
 				// Special case: If the mob is inside an object confirm the z-level on turf level.
-				if (H.z == 0 && (!pos || pos.z != z))
+				if (H.z == 0 && (!pos || (pos.get_virtual_z_level() != z)))
 					continue
 
 				I = H.wear_id ? H.wear_id.GetID() : null

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -22,7 +22,7 @@
 			current = null
 			return
 		var/turf/currentloc = get_turf(current)
-		if(currentloc && user.z != currentloc.z)
+		if(currentloc && user.get_virtual_z_level() != currentloc.get_virtual_z_level())
 			to_chat(user, "<span class='alert'>Upload failed! Unable to establish a connection to [current.name]. You're too far away!</span>")
 			current = null
 			return

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -158,7 +158,7 @@
 					dat += "<br><b>Medical Robots:</b>"
 					var/bdat = null
 					for(var/mob/living/simple_animal/bot/medbot/M in GLOB.alive_mob_list)
-						if(M.z != z)
+						if(M.get_virtual_z_level() != src.get_virtual_z_level())
 							continue	//only find medibots on the same z-level as the computer
 						var/turf/bl = get_turf(M)
 						if(bl)	//if it can't find a turf for the medibot, then it probably shouldn't be showing up

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -47,14 +47,14 @@
 
 	if(teleporter)
 		data["teleporter"] = teleporter
-		data["teleporter_location"] = "([teleporter.x], [teleporter.y], [teleporter.z])"
+		data["teleporter_location"] = "([teleporter.x], [teleporter.y], [teleporter.get_virtual_z_level()])"
 		data["teleporter_lock"] = teleporter.locked
 		data["teleporter_state_open"] = teleporter.state_open
 	else
 		data["teleporter"] = null
 	if(beacon)
 		data["beacon"] = beacon
-		data["beacon_location"] = "([beacon.x], [beacon.y], [beacon.z])"
+		data["beacon_location"] = "([beacon.x], [beacon.y], [beacon.get_virtual_z_level()])"
 	else
 		data["beacon"] = null
 	if(contained_id)

--- a/code/game/machinery/computer/prisoner/management.dm
+++ b/code/game/machinery/computer/prisoner/management.dm
@@ -35,7 +35,7 @@
 		var/turf/Tr = null
 		for(var/obj/item/implant/chem/C in GLOB.tracked_chem_implants)
 			Tr = get_turf(C)
-			if((Tr) && (Tr.z != src.z))
+			if((Tr) && (Tr.get_virtual_z_level() != src.get_virtual_z_level()))
 				continue//Out of range
 			if(!C.imp_in)
 				continue
@@ -50,7 +50,7 @@
 			if(!isliving(T.imp_in))
 				continue
 			Tr = get_turf(T)
-			if((Tr) && (Tr.z != src.z))
+			if((Tr) && (Tr.get_virtual_z_level() != src.get_virtual_z_level()))
 				continue//Out of range
 
 			var/loc_display = "Unknown"

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -42,7 +42,7 @@
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 		if(!can_control(user, R))
 			continue
-		if(z != (get_turf(R)).z)
+		if(get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
 			continue
 		var/list/cyborg_data = list(
 			name = R.name,
@@ -60,7 +60,7 @@
 	for(var/mob/living/simple_animal/drone/D in GLOB.drones_list)
 		if(D.hacked)
 			continue
-		if(z != (get_turf(D)).z)
+		if(get_virtual_z_level() != (get_turf(D)).get_virtual_z_level())
 			continue
 		var/list/drone_data = list(
 			name = D.name,

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -34,7 +34,7 @@
 	return data
 
 /obj/machinery/computer/station_alert/proc/triggerAlarm(class, area/A, O, obj/source)
-	if(source.z != z)
+	if(source.get_virtual_z_level() != get_virtual_z_level())
 		return
 	if(machine_stat & (BROKEN))
 		return

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -136,7 +136,7 @@
 	if(machine_stat & NOPOWER)
 		return FALSE
 	var/turf/zone = get_turf(src)
-	if(zone.z != epicenter.z)
+	if(zone.get_virtual_z_level() != epicenter.get_virtual_z_level())
 		return FALSE
 
 	if(next_announce > world.time)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -509,7 +509,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
   * *Areacheck for things that need to get into other areas, such as emergency holograms
   */
 /obj/machinery/holopad/proc/validate_location(turf/T, check_los = FALSE, areacheck = TRUE)
-	if(T.z == z && get_dist(T, src) <= holo_range && (T.loc == get_area(src) || !areacheck) && anchored)
+	if(T.get_virtual_z_level() == get_virtual_z_level() && get_dist(T, src) <= holo_range && (T.loc == get_area(src) || !areacheck) && anchored)
 		return TRUE
 	else
 		return FALSE

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -24,7 +24,7 @@
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
 		return
 	for(var/obj/singularity/singulo in GLOB.singularities)
-		if(singulo.z == z)
+		if(singulo.get_virtual_z_level() == get_virtual_z_level())
 			singulo.target = src
 	icon_state = "[icontype]1"
 	active = 1
@@ -95,7 +95,7 @@
 		if(cooldown <= world.time)
 			cooldown = world.time + 80
 			for(var/obj/singularity/singulo in GLOB.singularities)
-				if(singulo.z == z)
+				if(singulo.get_virtual_z_level() == get_virtual_z_level())
 					say("[singulo] is now [get_dist(src,singulo)] standard lengths away to the [dir2text(get_dir(src,singulo))]")
 	else
 		Deactivate()

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -120,7 +120,7 @@
 		"mods" = message_mods
 	)
 	var/turf/T = get_turf(source)
-	levels = list(T.z)
+	levels = list(T.get_virtual_z_level())
 
 /datum/signal/subspace/vocal/copy()
 	var/datum/signal/subspace/vocal/copy = new(source, frequency, virt, language)
@@ -153,7 +153,7 @@
 			// Syndicate radios can hear all well-known radio channels
 			if (num2text(frequency) in GLOB.reverseradiochannels)
 				for(var/obj/item/radio/R in GLOB.all_radios["[FREQ_SYNDICATE]"])
-					if(R.can_receive(FREQ_SYNDICATE, list(R.z)))
+					if(R.can_receive(FREQ_SYNDICATE, list(R.get_virtual_z_level())))
 						radios |= R
 
 		if (TRANSMISSION_RADIO)

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -26,7 +26,7 @@
 		return
 	if(!on || !is_freq_listening(signal))  // has to be on to receive messages
 		return
-	if (!intercept && !(z in signal.levels) && !(0 in signal.levels))  // has to be syndicate or on the right level
+	if (!intercept && !(get_virtual_z_level() in signal.levels) && !(0 in signal.levels))  // has to be syndicate or on the right level
 		return
 
 	// Decompress the signal and mark it done

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(message_delay, 0) // To make sure restarting the recentmessages 
 
 	var/turf/T = get_turf(src)
 	if (T)
-		signal.levels |= T.z
+		signal.levels |= T.get_virtual_z_level()
 
 	var/signal_message = "[signal.frequency]:[signal.data["message"]]:[signal.data["name"]]"
 	if(signal_message in GLOB.recentmessages)

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -162,7 +162,7 @@
 	source = init_source
 	data = init_data
 	var/turf/T = get_turf(source)
-	levels = list(T.z)
+	levels = list(T.get_virtual_z_level())
 	if(!("reject" in data))
 		data["reject"] = TRUE
 

--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -28,12 +28,12 @@
 		relay_information(signal, /obj/machinery/telecomms/bus)
 
 /obj/machinery/telecomms/receiver/proc/check_receive_level(datum/signal/subspace/signal)
-	if (z in signal.levels)
+	if (get_virtual_z_level() in signal.levels)
 		return TRUE
 
 	for(var/obj/machinery/telecomms/hub/H in links)
 		for(var/obj/machinery/telecomms/relay/R in H.links)
-			if(R.can_receive(signal) && (R.z in signal.levels))
+			if(R.can_receive(signal) && (R.get_virtual_z_level() in signal.levels))
 				return TRUE
 
 	return FALSE

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -23,7 +23,7 @@
 	// Add our level and send it back
 	var/turf/T = get_turf(src)
 	if(can_send(signal) && T)
-		signal.levels |= T.z
+		signal.levels |= T.get_virtual_z_level()
 
 // Checks to see if it can send/receive.
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 			continue
 		if(amount && send_count >= amount)
 			break
-		if(z != machine.loc.z && !long_range_link && !machine.long_range_link)
+		if(get_virtual_z_level() != machine.loc.get_virtual_z_level() && !long_range_link && !machine.long_range_link)
 			continue
 
 		send_count++
@@ -102,7 +102,7 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 /obj/machinery/telecomms/proc/add_link(obj/machinery/telecomms/T)
 	var/turf/position = get_turf(src)
 	var/turf/T_position = get_turf(T)
-	if((position.z == T_position.z) || (long_range_link && T.long_range_link))
+	if((position.get_virtual_z_level() == T_position.get_virtual_z_level()) || (long_range_link && T.long_range_link))
 		if(src != T)
 			for(var/x in autolinkers)
 				if(x in T.autolinkers)

--- a/code/game/mecha/equipment/tools/other_tools.dm
+++ b/code/game/mecha/equipment/tools/other_tools.dm
@@ -44,7 +44,7 @@
 	var/list/L = list()
 	var/turf/pos = get_turf(src)
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density && pos.z == T.z)
+		if(!T.density && pos.get_virtual_z_level() == T.get_virtual_z_level())
 			var/clear = 1
 			for(var/obj/O in T)
 				if(O.density)

--- a/code/game/objects/effects/step_triggers.dm
+++ b/code/game/objects/effects/step_triggers.dm
@@ -69,7 +69,7 @@
 		if(tiles)
 			if(curtiles >= tiles)
 				break
-		if(AM.z != src.z)
+		if(AM.get_virtual_z_level() != src.get_virtual_z_level())
 			break
 
 		curtiles++

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -261,7 +261,7 @@ Code:
 			for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
 				if(pMon.machine_stat & (NOPOWER | BROKEN)) //check to make sure the computer is functional
 					continue
-				if(pda_turf.z != pMon.z) //and that we're on the same zlevel as the computer (lore: limited signal strength)
+				if(pda_turf.get_virtual_z_level() != pMon.get_virtual_z_level()) //and that we're on the same zlevel as the computer (lore: limited signal strength)
 					continue
 				if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame that the location exists
 					continue
@@ -469,7 +469,7 @@ Code:
 					var/turf/ml = get_turf(M)
 
 					if(ml)
-						if (ml.z != cl.z)
+						if (ml.get_virtual_z_level() != cl.get_virtual_z_level())
 							continue
 						var/direction = get_dir(src, M)
 						ldat += "Mop - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b> - [M.reagents.total_volume ? "Wet" : "Dry"]<br>"
@@ -486,7 +486,7 @@ Code:
 					var/turf/bl = get_turf(B)
 
 					if(bl)
-						if (bl.z != cl.z)
+						if (bl.get_virtual_z_level() != cl.get_virtual_z_level())
 							continue
 						var/direction = get_dir(src, B)
 						ldat += "Cart - <b>\[[bl.x],[bl.y] ([uppertext(dir2text(direction))])\]</b> - Water level: [B.reagents.total_volume]/100<br>"
@@ -503,7 +503,7 @@ Code:
 					var/turf/bl = get_turf(B)
 
 					if(bl)
-						if (bl.z != cl.z)
+						if (bl.get_virtual_z_level() != cl.get_virtual_z_level())
 							continue
 						var/direction = get_dir(src, B)
 						ldat += "Cleanbot - <b>\[[bl.x],[bl.y] ([uppertext(dir2text(direction))])\]</b> - [B.on ? "Online" : "Offline"]<br>"
@@ -717,11 +717,11 @@ Code:
 	else
 		menu += "<BR><A href='byond://?src=[REF(src)];op=botlist'>[PDAIMG(refresh)]Scan for active bots</A><BR><BR>"
 		var/turf/current_turf = get_turf(src)
-		var/zlevel = current_turf.z
+		var/zlevel = current_turf.get_virtual_z_level()
 		var/botcount = 0
 		for(var/B in GLOB.bots_list) //Git da botz
 			var/mob/living/simple_animal/bot/Bot = B
-			if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled || !(bot_access_flags & Bot.bot_type)) //Only non-emagged bots on the same Z-level are detected!
+			if(!Bot.on || Bot.get_virtual_z_level() != zlevel || Bot.remote_disabled || !(bot_access_flags & Bot.bot_type)) //Only non-emagged bots on the same Z-level are detected!
 				continue //Also, the PDA must have access to the bot type.
 			menu += "[PDAIMG(medbot)]   <A href='byond://?src=[REF(src)];op=control;bot=[REF(Bot)]'><b>[Bot.name]</b> ([Bot.get_mode()])</a><BR>"
 			botcount++

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -65,7 +65,7 @@
 		return 0
 	var/turf/T_user = get_turf(user.loc)
 	var/turf/T_current = get_turf(current)
-	if(T_user.z != T_current.z || !current.can_use())
+	if(T_user.get_virtual_z_level() != T_current.get_virtual_z_level() || !current.can_use())
 		to_chat(user, "<span class='danger'>[src] has lost the signal.</span>")
 		current = null
 		user.unset_machine()
@@ -301,7 +301,7 @@
 /obj/item/camera_bug/proc/same_z_level(var/obj/machinery/camera/C)
 	var/turf/T_cam = get_turf(C)
 	var/turf/T_bug = get_turf(loc)
-	if(!T_bug || T_cam.z != T_bug.z)
+	if(!T_bug || T_cam.get_virtual_z_level() != T_bug.get_virtual_z_level())
 		to_chat(usr, "<span class='warning'>You can't get a signal!</span>")
 		return FALSE
 	return TRUE

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -59,7 +59,7 @@
 		// I assume it's faster to color,tag and OR the turf in, rather
 		// then checking if its there
 		T.color = RANDOM_COLOUR
-		T.maptext = "[T.x],[T.y],[T.z]"
+		T.maptext = "[T.x],[T.y],[T.get_virtual_z_level()]"
 		tagged |= T
 
 /obj/item/gps/visible_debug/proc/clear()

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -76,7 +76,7 @@
 		return FALSE
 	if(!(0 in level))
 		var/turf/position = get_turf(src)
-		if(isnull(position) || !(position.z in level))
+		if(isnull(position) || !(position.get_virtual_z_level() in level))
 			return FALSE
 	if(!listening)
 		return FALSE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -230,7 +230,7 @@
 	var/turf/position = get_turf(src)
 	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
 		var/turf/jammer_turf = get_turf(jammer)
-		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+		if(position?.get_virtual_z_level() == jammer_turf.get_virtual_z_level() && (get_dist(position, jammer_turf) <= jammer.range))
 			return
 
 	// Determine the identity information which will be attached to the signal.
@@ -264,7 +264,7 @@
 
 /obj/item/radio/proc/backup_transmission(datum/signal/subspace/vocal/signal)
 	var/turf/T = get_turf(src)
-	if (signal.data["done"] && (T.z in signal.levels))
+	if (signal.data["done"] && (T.get_virtual_z_level() in signal.levels))
 		return
 
 	// Okay, the signal was never processed, send a mundane broadcast.
@@ -300,7 +300,7 @@
 		return independent  // hard-ignores the z-level check
 	if (!(0 in level))
 		var/turf/position = get_turf(src)
-		if(!position || !(position.z in level))
+		if(!position || !(position.get_virtual_z_level() in level))
 			return FALSE
 
 	// allow checks: are we listening on that frequency?

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -270,7 +270,7 @@
 	// Okay, the signal was never processed, send a mundane broadcast.
 	signal.data["compression"] = 0
 	signal.transmission_method = TRANSMISSION_RADIO
-	signal.levels = list(T.z)
+	signal.levels = list(T.get_virtual_z_level())
 	signal.broadcast()
 
 /obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -105,7 +105,7 @@
 			return FALSE
 
 		var/turf/there = get_turf(H)
-		return (H.z != 0 || (there && ((there.get_virtual_z_level() == here.get_virtual_z_level()))
+		return (H.z != 0 || (there && ((there.get_virtual_z_level() == here.get_virtual_z_level()))))
 
 	return FALSE
 

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -66,7 +66,7 @@
 		return
 	var/turf/here = get_turf(src)
 	var/turf/there = get_turf(target)
-	if(here.z != there.z)
+	if(here.get_virtual_z_level() != there.get_virtual_z_level())
 		. += "pinon[alert ? "alert" : ""]null[icon_suffix]"
 		return
 	. += get_direction_icon(here, there)
@@ -97,7 +97,7 @@
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)
-	if((H.z == 0 || H.z == here.z) && istype(H.w_uniform, /obj/item/clothing/under))
+	if((H.z == 0 || H.get_virtual_z_level() == here.get_virtual_z_level()) && istype(H.w_uniform, /obj/item/clothing/under))
 		var/obj/item/clothing/under/U = H.w_uniform
 
 		// Suit sensors must be on maximum.
@@ -105,7 +105,7 @@
 			return FALSE
 
 		var/turf/there = get_turf(H)
-		return (H.z != 0 || (there && there.z == here.z))
+		return (H.z != 0 || (there && ((there.get_virtual_z_level() == here.get_virtual_z_level()))
 
 	return FALSE
 

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -49,7 +49,7 @@
 			var/turf/tr = get_turf(W)
 
 			// Make sure it's on a turf and that its Z-level matches the tracker's Z-level
-			if (tr && tr.z == sr.z)
+			if (tr && tr.get_virtual_z_level() == sr.get_virtual_z_level())
 				// Get the distance between the beacon's turf and our turf
 				var/distance = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
 

--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -135,7 +135,7 @@
 					hearing_mobs += M
 		if(SOUND_EMITTER_ZLEVEL)
 			for(var/mob/M in GLOB.player_list)
-				if(M.z == z)
+				if(M.get_virtual_z_level() == get_virtual_z_level())
 					hearing_mobs += M
 		if(SOUND_EMITTER_GLOBAL)
 			hearing_mobs = GLOB.player_list.Copy()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -650,7 +650,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 /obj/effect/rune/wall/proc/spread_density()
 	for(var/R in GLOB.wall_runes)
 		var/obj/effect/rune/wall/W = R
-		if(W.z == z && get_dist(src, W) <= 2 && !W.density && !W.recharging)
+		if(W.get_virtual_z_level() == get_virtual_z_level() && get_dist(src, W) <= 2 && !W.density && !W.recharging)
 			W.density = TRUE
 			W.update_state()
 			W.spread_density()
@@ -964,10 +964,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 		L.Paralyze(30)
 	empulse(T, 0.42*(intensity), 1)
 	var/list/images = list()
-	var/zmatch = T.z
+	var/zmatch = T.get_virtual_z_level()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_SECURITY_ADVANCED]
 	for(var/mob/living/M in GLOB.alive_mob_list)
-		if(M.z != zmatch)
+		if(M.get_virtual_z_level() != zmatch)
 			continue
 		if(ishuman(M))
 			if(!iscultist(M))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -497,7 +497,7 @@
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
-	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, z)
+	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, get_virtual_z_level())
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < 2)
@@ -576,7 +576,7 @@
 	if(!z)
 		return
 	for(var/mob/M in GLOB.mob_list)
-		if(M.stat != DEAD && M.z == z)
+		if(M.stat != DEAD && M.get_virtual_z_level() == z)
 			M.gib()
 
 /*

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -61,7 +61,7 @@
 		return
 	var/turf/here = get_turf(owner)
 	var/turf/there = get_turf(scan_target)
-	if(here.z != there.z)
+	if(here.get_virtual_z_level() != there.get_virtual_z_level())
 		linked_alert.icon_state = "pinonnull"
 		return
 	if(get_dist_euclidian(here,there)<=minimum_range + rand(0, range_fuzz_factor))

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -441,7 +441,7 @@
 	var/breakout = 0
 	while(breakout < 50)
 		var/turf/potential_T = find_safe_turf()
-		if(T.z != potential_T.z || abs(get_dist_euclidian(potential_T,T)) > 50 - breakout)
+		if(T.get_virtual_z_level() != potential_T.get_virtual_z_level() || abs(get_dist_euclidian(potential_T,T)) > 50 - breakout)
 			do_teleport(user, potential_T, channel = TELEPORT_CHANNEL_MAGIC)
 			T = potential_T
 			break

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -107,7 +107,7 @@
 	if(next_check < world.time)
 		if(!current_wizard)
 			for(var/mob/living/L in GLOB.player_list)
-				if(L.z == src.z && L.stat != DEAD && !(faction in L.faction))
+				if(L.get_virtual_z_level() == src.get_virtual_z_level() && L.stat != DEAD && !(faction in L.faction))
 					summon_wizard()
 					break
 		else

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -171,7 +171,7 @@
 		if(user && ishuman(user) && (user.wear_suit == src))
 			if(camera && (user.remote_control == camera))
 				if(!teleporting)
-					if(camera.loc != user && ((camera.x != user.x) || (camera.y != user.y) || (camera.z != user.z)))
+					if(camera.loc != user && ((camera.x != user.x) || (camera.y != user.y) || (camera.get_virtual_z_level() != user.get_virtual_z_level())))
 						if(camera.phase_time <= world.time)
 							chronowalk(camera)
 					else

--- a/code/modules/mapping/space_management/space_reservation.dm
+++ b/code/modules/mapping/space_management/space_reservation.dm
@@ -3,7 +3,6 @@
 //Yes, I'm sorry.
 /datum/turf_reservation
 	var/list/reserved_turfs = list()
-	var/list/non_border_turfs
 	var/width = 0
 	var/height = 0
 	var/bottom_left_coords[3]
@@ -12,6 +11,7 @@
 	var/turf_type = /turf/open/space
 	var/border_turf_type
 	var/area/area_type
+	var/virtual_z_level
 
 /datum/turf_reservation/transit
 	turf_type = /turf/open/space/transit
@@ -65,17 +65,15 @@
 		SSmapping.used_turfs[T] = src
 		if(border_turf_type && T.x == BL.x || T.x == TR.x || T.y == BL.y || T.y == TR.y)
 			T.ChangeTurf(border_turf_type, turf_type)
-		else if(border_turf_type)
-			LAZYADD(non_border_turfs, T)
-			T.ChangeTurf(turf_type, turf_type)
 		else
 			T.ChangeTurf(turf_type, turf_type)
-		if(area_type)
-			if(ispath(area_type))
-				area_type = new area_type
-			var/area/old_area = get_area(T)
-			area_type.contents += T
-			T.change_area(old_area, area_type)
+			if(area_type)
+				if(ispath(area_type))
+					area_type = new area_type
+				var/area/old_area = get_area(T)
+				area_type.contents += T
+				T.change_area(old_area, area_type)
+	virtual_z_level = get_new_virtual_z()
 	src.width = width
 	src.height = height
 	return TRUE

--- a/code/modules/mob/living/carbon/alien/screen.dm
+++ b/code/modules/mob/living/carbon/alien/screen.dm
@@ -14,7 +14,7 @@
 			return
 		var/turf/Q = get_turf(queen)
 		var/turf/A = get_turf(src)
-		if(Q.z != A.z) //The queen is on a different Z level, we cannot sense that far.
+		if(Q.get_virtual_z_level() != A.get_virtual_z_level()) //The queen is on a different Z level, we cannot sense that far.
 			return
 		var/Qdir = get_dir(src, Q)
 		var/Qdist = get_dist(src, Q)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 				continue	//Remove if underlying cause (likely byond issue) is fixed. See TG PR #49004.
 			if(M.stat != DEAD) //not dead, not important
 				continue
-			if(get_dist(M, src) > 7 || M.z != z) //they're out of range of normal hearing
+			if(get_dist(M, src) > 7 || M.get_virtual_z_level() != get_virtual_z_level()) //they're out of range of normal hearing
 				if(eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
 					continue
 				if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -333,7 +333,7 @@
 	if(!target)
 		return
 
-	if ((ai.z != target.z) && !is_station_level(ai.z))
+	if ((ai.get_virtual_z_level() != target.get_virtual_z_level()) && !is_station_level(ai.z))
 		return FALSE
 
 	if (istype(loc, /obj/item/aicard))
@@ -493,7 +493,7 @@
 	call_bot_cooldown = 0
 
 /mob/living/silicon/ai/triggerAlarm(class, area/A, O, obj/alarmsource)
-	if(alarmsource.z != z)
+	if(alarmsource.get_virtual_z_level() != get_virtual_z_level())
 		return
 	var/list/L = alarms[class]
 	for (var/I in L)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -139,7 +139,7 @@
 /atom/proc/move_camera_by_click()
 	if(isAI(usr))
 		var/mob/living/silicon/ai/AI = usr
-		if(AI.eyeobj && (AI.multicam_on || (AI.client.eye == AI.eyeobj)) && (AI.eyeobj.z == z))
+		if(AI.eyeobj && (AI.multicam_on || (AI.client.eye == AI.eyeobj)) && (AI.eyeobj.get_virtual_z_level() == get_virtual_z_level()))
 			AI.cameraFollow = null
 			if (isturf(loc) || isturf(src))
 				AI.eyeobj.setLoc(src)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -125,7 +125,7 @@
 	log_game("[key_name(src)] made a vocal announcement with the following message: [message].")
 
 	for(var/word in words)
-		play_vox_word(word, src.z, null)
+		play_vox_word(word, src.get_virtual_z_level(), null)
 
 
 /proc/play_vox_word(word, z_level, mob/only_listener)
@@ -144,7 +144,7 @@
 			for(var/mob/M in GLOB.player_list)
 				if(M.can_hear() && (M.client.prefs.toggles & SOUND_ANNOUNCEMENTS))
 					var/turf/T = get_turf(M)
-					if(T.z == z_level)
+					if(T.get_virtual_z_level() == z_level)
 						SEND_SOUND(M, voice)
 		else
 			SEND_SOUND(only_listener, voice)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -328,7 +328,7 @@
 
 
 /mob/living/silicon/robot/triggerAlarm(class, area/A, O, obj/alarmsource)
-	if(alarmsource.z != z)
+	if(alarmsource.get_virtual_z_level() != get_virtual_z_level())
 		return
 	if(stat == DEAD)
 		return 1

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -262,7 +262,7 @@
   * * alarmsource - [/atom] source of the alarm
   */
 /mob/living/simple_animal/drone/proc/triggerAlarm(class, area/A, O, obj/alarmsource)
-	if(alarmsource.z != z)
+	if(alarmsource.get_virtual_z_level() != get_virtual_z_level())
 		return
 	if(stat != DEAD)
 		var/list/L = src.alarms[class]

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -124,7 +124,7 @@
 		return
 
 	var/turf/T = get_turf(A)
-	if(beacon.z != T.z)
+	if(beacon.get_virtual_z_level() != T.get_virtual_z_level())
 		to_chat(src, "<span class='danger'><B>The beacon is too far away to warp to!</span></B>")
 		return
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -268,7 +268,7 @@
 		return 0
 	if(target in possible_targets)
 		var/turf/T = get_turf(src)
-		if(target.z != T.z)
+		if(target.get_virtual_z_level() != T.get_virtual_z_level())
 			LoseTarget()
 			return 0
 		var/target_distance = get_dist(targets_from,target)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -146,7 +146,7 @@
 
 /mob/living/simple_animal/hostile/jungle/seedling/proc/Beamu(mob/living/living_target, beam_id = 0)
 	if(combatant_state == SEEDLING_STATE_ACTIVE && living_target && beam_id == solar_beam_identifier)
-		if(living_target.z == z)
+		if(living_target.get_virtual_z_level() == get_virtual_z_level())
 			update_icons()
 			var/obj/effect/temp_visual/solarbeam_killsat/S = new (get_turf(src))
 			var/matrix/starting = matrix()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -132,7 +132,7 @@ Difficulty: Medium
 		new /obj/effect/temp_visual/dir_setting/miner_death(loc, dir)
 
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/Move(atom/newloc)
-	if(dashing || (newloc && newloc.z == z && (islava(newloc) || ischasm(newloc)))) //we're not stupid!
+	if(dashing || (newloc && newloc.get_virtual_z_level() == get_virtual_z_level() && (islava(newloc) || ischasm(newloc)))) //we're not stupid!
 		return FALSE
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -130,7 +130,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 /mob/living/simple_animal/hostile/swarmer/ai/Move(atom/newloc)
 	if(newloc)
-		if(newloc.z == z) //so these actions are Z-specific
+		if(newloc.get_virtual_z_level() == get_virtual_z_level()) //so these actions are Z-specific
 			if(islava(newloc))
 				var/turf/open/lava/L = newloc
 				if(!L.is_safe())

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -186,7 +186,7 @@
 					dropoff_turf = content
 					break
 
-			if(curr.z == dropoff_turf.z) //Direction calculations for same z-level only
+			if(curr.get_virtual_z_level() == dropoff_turf.get_virtual_z_level()) //Direction calculations for same z-level only
 				direction = uppertext(dir2text(get_dir(curr, dropoff_turf))) //Direction text (East, etc). Not as precise, but still helpful.
 				if(get_area(user) == traitor_data.contractor_hub.current_contract.contract.dropoff)
 					direction = "LOCATION CONFIRMED"

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -72,7 +72,7 @@
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
 /datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)
-	if((get_turf(computer)).z != (get_turf(R)).z)
+	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
 		return FALSE
 	if(R.scrambledcodes)
 		return FALSE
@@ -98,7 +98,7 @@
 	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
 
 /datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
-	if((get_turf(computer)).z != (get_turf(R)).z)
+	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
 		return FALSE
 	if(!R.scrambledcodes)
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -19,7 +19,7 @@
 /datum/computer_file/program/robocontrol/ui_data(mob/user)
 	var/list/data = get_header_data()
 	var/turf/current_turf = get_turf(ui_host())
-	var/zlevel = current_turf.z
+	var/zlevel = current_turf.get_virtual_z_level()
 	var/list/botlist = list()
 	var/list/mulelist = list()
 
@@ -36,7 +36,7 @@
 
 	for(var/B in GLOB.bots_list)
 		var/mob/living/simple_animal/bot/Bot = B
-		if(!Bot.on || Bot.z != zlevel || Bot.remote_disabled) //Only non-emagged bots on the same Z-level are detected!
+		if(!Bot.on || Bot.get_virtual_z_level() != zlevel || Bot.remote_disabled) //Only non-emagged bots on the same Z-level are detected!
 			continue
 		else if(computer) //Also, the inserted ID must have access to the bot type
 			var/obj/item/card/id/id_card = card_slot ? card_slot.stored_card : null

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -47,7 +47,7 @@
 		return
 	for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
 		// Delaminating, not within coverage, not on a tile.
-		if (!isturf(S.loc) || !(is_station_level(S.z) || is_mining_level(S.z) || S.z == T.z))
+		if (!isturf(S.loc) || !(is_station_level(S.z) || is_mining_level(S.z) || S.get_virtual_z_level() == T.get_virtual_z_level()))
 			continue
 		supermatters.Add(S)
 

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -351,7 +351,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	var/sound/alert_sound = sound('sound/effects/alert.ogg')
 	for(var/i in GLOB.mob_list)
 		var/mob/M = i
-		if(M.z != z && !(SSmapping.level_trait(z, ZTRAITS_STATION) && SSmapping.level_trait(M.z, ZTRAITS_STATION)))
+		if(M.get_virtual_z_level() != get_virtual_z_level() && !(SSmapping.level_trait(z, ZTRAITS_STATION) && SSmapping.level_trait(M.z, ZTRAITS_STATION)))
 			continue
 		M.update_gravity(M.mob_has_gravity())
 		if(M.client)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -362,8 +362,8 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	var/turf/T = get_turf(src)
 	if(!T)
 		return FALSE
-	if(GLOB.gravity_generators["[T.z]"])
-		return length(GLOB.gravity_generators["[T.z]"])
+	if(GLOB.gravity_generators["[T.get_virtual_z_level()]"])
+		return length(GLOB.gravity_generators["[T.get_virtual_z_level()]"])
 	return FALSE
 
 /obj/machinery/gravity_generator/main/proc/update_list()

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -175,7 +175,7 @@
 
 	for(var/mob/living/carbon/food in GLOB.alive_mob_list) //we don't care about constructs or cult-Ians or whatever. cult-monkeys are fair game i guess
 		var/turf/pos = get_turf(food)
-		if(!pos || (pos.z != z))
+		if(!pos || (pos.get_virtual_z_level() != get_virtual_z_level()))
 			continue
 
 		if(iscultist(food))
@@ -194,7 +194,7 @@
 	//no living humans, follow a ghost instead.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
 		var/turf/pos = get_turf(ghost)
-		if(!pos || (pos.z != z))
+		if(!pos || (pos.get_virtual_z_level() != get_virtual_z_level()))
 			continue
 		cultists += ghost
 	if(cultists.len)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -384,7 +384,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 /obj/machinery/power/supermatter_crystal/proc/explode()
 	for(var/mob in GLOB.alive_mob_list)
 		var/mob/living/L = mob
-		if(istype(L) && L.z == z)
+		if(istype(L) && L.get_virtual_z_level() == get_virtual_z_level())
 			if(ishuman(mob))
 				//Hilariously enough, running into a closet should make you get hit the hardest.
 				var/mob/living/carbon/human/H = mob
@@ -394,7 +394,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	var/turf/T = get_turf(src)
 	for(var/mob/M in GLOB.player_list)
-		if(M.z == z)
+		if(M.get_virtual_z_level() == get_virtual_z_level())
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
@@ -739,7 +739,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	message_admins("Singularity has consumed a supermatter shard and can now become stage six.")
 	visible_message("<span class='userdanger'>[src] is consumed by the singularity!</span>")
 	for(var/mob/M in GLOB.player_list)
-		if(M.z == z)
+		if(M.get_virtual_z_level() == get_virtual_z_level())
 			SEND_SOUND(M, 'sound/effects/supermatter.ogg') //everyone goan know bout this
 			to_chat(M, "<span class='boldannounce'>A horrible screeching fills your ears, and a wave of dread washes over you...</span>")
 	qdel(src)

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -182,7 +182,7 @@ GLOBAL_DATUM(necropolis_gate, /obj/structure/necropolis_gate/legion_gate)
 
 		var/sound/legion_sound = sound('sound/creatures/legion_spawn.ogg')
 		for(var/mob/M in GLOB.player_list)
-			if(M.z == z)
+			if(M.get_virtual_z_level() == get_virtual_z_level())
 				to_chat(M, "<span class='userdanger'>Discordant whispers flood your mind in a thousand voices. Each one speaks your name, over and over. Something horrible has been released.</span>")
 				M.playsound_local(T, null, 100, FALSE, 0, FALSE, pressure_affected = FALSE, S = legion_sound)
 				flash_color(M, flash_color = "#FF0000", flash_time = 50)

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -129,6 +129,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
     currentArea.storageTurf = storageTurf
     currentArea.roomnumber = currentRoomnumber
     currentArea.reservation = currentReservation
+	currentArea.virtual_z_value = get_new_virtual_z()
     for(var/turf/closed/indestructible/hoteldoor/door in currentArea)
         door.parentSphere = src
         door.desc = "The door to this hotel room. The placard reads 'Room [currentRoomnumber]'. Strange, this door doesnt even seem openable. The doorknob, however, seems to buzz with unusual energy...<br /><span class='info'>Alt-Click to look through the peephole.</span>"
@@ -322,6 +323,13 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	var/obj/item/hilbertshotel/parentSphere
 	var/datum/turf_reservation/reservation
 	var/turf/storageTurf
+	var/virtual_z_value
+
+/area/hilbertshotel/get_virtual_z()
+	if(virtual_z_value)
+		return virtual_z_value
+	else
+		return ..()
 
 /area/hilbertshotel/Entered(atom/movable/AM)
     . = ..()

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -129,7 +129,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
     currentArea.storageTurf = storageTurf
     currentArea.roomnumber = currentRoomnumber
     currentArea.reservation = currentReservation
-	currentArea.virtual_z_value = get_new_virtual_z()
+    currentArea.virtual_z_value = get_new_virtual_z()
     for(var/turf/closed/indestructible/hoteldoor/door in currentArea)
         door.parentSphere = src
         door.desc = "The door to this hotel room. The placard reads 'Room [currentRoomnumber]'. Strange, this door doesnt even seem openable. The doorknob, however, seems to buzz with unusual energy...<br /><span class='info'>Alt-Click to look through the peephole.</span>"

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -73,7 +73,7 @@
 	for(var/V in shuttle_port.shuttle_areas)
 		var/area/A = V
 		for(var/turf/T in A)
-			if(T.z != origin.z)
+			if(T.get_virtual_z_level() != origin.get_virtual_z_level())
 				continue
 			var/image/I = image('icons/effects/alphacolors.dmi', origin, "red")
 			var/x_off = T.x - origin.x

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -299,9 +299,6 @@
 	///The linked overmap object, if there is one
 	var/obj/structure/overmap/ship/simulated/current_ship
 
-	//The virtual Z-Value of the shuttle
-	var/virtual_z
-
 /obj/docking_port/mobile/proc/register()
 	SSshuttle.mobile += src
 
@@ -340,8 +337,6 @@
 
 	if(SSovermap.initialized)
 		SSovermap.setup_shuttle_ship(src)
-
-	virtual_z = get_new_virtual_z()
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#0f0")
@@ -927,3 +922,7 @@
 
 /obj/docking_port/mobile/emergency/on_emergency_dock()
 	return
+
+/obj/docking_port/mobile/get_virtual_z_level()
+	var/datum/turf_reservation/TR = SSmapping.get_turf_reservation_at_coords(x, y, z)
+	return TR?.virtual_z_level || z

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -299,6 +299,9 @@
 	///The linked overmap object, if there is one
 	var/obj/structure/overmap/ship/simulated/current_ship
 
+	//The virtual Z-Value of the shuttle
+	var/virtual_z
+
 /obj/docking_port/mobile/proc/register()
 	SSshuttle.mobile += src
 
@@ -326,15 +329,19 @@
 	var/list/all_turfs = return_ordered_turfs(x, y, z, dir)
 	for(var/i in 1 to all_turfs.len)
 		var/turf/curT = all_turfs[i]
-		var/area/cur_area = curT.loc
+		var/area/shuttle/cur_area = curT.loc
 		if(istype(cur_area, area_type))
 			shuttle_areas[cur_area] = TRUE
+			if(!cur_area.mobile_port)
+				cur_area.link_to_shuttle(src)
 
 	initial_engines = count_engines()
 	current_engines = initial_engines
 
 	if(SSovermap.initialized)
 		SSovermap.setup_shuttle_ship(src)
+
+	virtual_z = get_new_virtual_z()
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#0f0")

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -60,7 +60,7 @@
 
 /obj/machinery/computer/sat_control/proc/toggle(id)
 	for(var/obj/machinery/satellite/S in GLOB.machines)
-		if(S.id == id && S.z == z)
+		if(S.id == id && S.get_virtual_z_level() == get_virtual_z_level())
 			S.toggle()
 
 /obj/machinery/computer/sat_control/ui_data()
@@ -152,7 +152,7 @@
 	if(!active)
 		return
 	for(var/obj/effect/meteor/M in GLOB.meteor_list)
-		if(M.z != z)
+		if(M.get_virtual_z_level() != get_virtual_z_level())
 			continue
 		if(get_dist(M,src) > kill_range)
 			continue

--- a/code/modules/tgui/states/zlevel.dm
+++ b/code/modules/tgui/states/zlevel.dm
@@ -12,6 +12,6 @@ GLOBAL_DATUM_INIT(z_state, /datum/ui_state/z_state, new)
 /datum/ui_state/z_state/can_use_topic(src_object, mob/user)
 	var/turf/turf_obj = get_turf(src_object)
 	var/turf/turf_usr = get_turf(user)
-	if(turf_obj && turf_usr && turf_obj.z == turf_usr.z)
+	if(turf_obj && turf_usr && turf_obj.get_virtual_z_level() == turf_usr.get_virtual_z_level())
 		return UI_INTERACTIVE
 	return UI_CLOSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -185,6 +185,7 @@
 #include "code\__HELPERS\unsorted.dm"
 #include "code\__HELPERS\verbs.dm"
 #include "code\__HELPERS\view.dm"
+#include "code\__HELPERS\virtual_z_level.dm"
 #include "code\__HELPERS\sorts\__main.dm"
 #include "code\__HELPERS\sorts\InsertSort.dm"
 #include "code\__HELPERS\sorts\MergeSort.dm"

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(overmap)
   * * Shuttle: The docking port to create an overmap object for
   */
 /datum/controller/subsystem/overmap/proc/setup_shuttle_ship(obj/docking_port/mobile/shuttle)
-	var/docked_object = get_overmap_object_by_z(shuttle.z)
+	var/docked_object = get_overmap_object_by_z(get_virtual_z_level(shuttle))
 	if(docked_object)
 		shuttle.current_ship = new /obj/structure/overmap/ship/simulated(docked_object, shuttle.id, shuttle)
 		if(shuttle.undock_roundstart)
@@ -305,22 +305,23 @@ SUBSYSTEM_DEF(overmap)
 			if(DYNAMIC_WORLD_LAVA)
 				ruin_list = SSmapping.lava_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/lavaland
-				target_area = /area/ruin/unpowered/planetoid/lava
+				target_area = /area/overmap_encounter/planetoid/lava
 			if(DYNAMIC_WORLD_ICE)
 				ruin_list = SSmapping.ice_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/icemoon/surface
-				target_area = /area/ruin/unpowered/planetoid/ice
+				target_area = /area/overmap_encounter/planetoid/ice
 			if(DYNAMIC_WORLD_SAND)
 				ruin_list = SSmapping.sand_ruins_templates
 				mapgen = new /datum/map_generator/cave_generator/whitesands
-				target_area = /area/ruin/unpowered/planetoid/sand
+				target_area = /area/overmap_encounter/planetoid/sand
 			if(DYNAMIC_WORLD_JUNGLE)
 				ruin_list = SSmapping.jungle_ruins_templates
 				mapgen = new /datum/map_generator/jungle_generator
-				target_area = /area/ruin/unpowered/planetoid/jungle
+				target_area = /area/overmap_encounter/planetoid/jungle
 			if(DYNAMIC_WORLD_ASTEROID)
 				ruin_list = null
 				mapgen = new /datum/map_generator/cave_generator/asteroid
+				target_area = /area/overmap_encounter
 
 	if(ruin && ruin_list && !ruin_type) //Done BEFORE the turfs are reserved so that it allocates the right size box
 		ruin_type = ruin_list[pick(ruin_list)]
@@ -339,12 +340,7 @@ SUBSYSTEM_DEF(overmap)
 		ruin_type.load(ruin_turf)
 
 	if(mapgen) //Does AFTER the ruin is loaded so that it does not spawn flora/fauna in the ruin
-		var/list/same_area_turfs = list()
-		for(var/turf/T as anything in encounter_reservation.non_border_turfs)
-			if(target_area && T.loc?.type != target_area)
-				continue
-			same_area_turfs += T
-		mapgen.generate_terrain(same_area_turfs)
+		mapgen.generate_terrain(encounter_reservation.area_type.contents)
 
 	//gets the turf with an X in the middle of the reservation, and a Y that's 1/4ths up in the reservation.
 	var/turf/docking_turf = locate(encounter_reservation.bottom_left_coords[1] + dock_size, encounter_reservation.bottom_left_coords[2] + FLOOR(dock_size / 2, 1), encounter_reservation.bottom_left_coords[3])
@@ -446,11 +442,14 @@ SUBSYSTEM_DEF(overmap)
   */
 /datum/controller/subsystem/overmap/proc/get_overmap_object_by_z(zlevel)
 	for(var/id in overmap_objects)
-		if(!istype(overmap_objects[id], /obj/structure/overmap/level))
-			continue
-		var/obj/structure/overmap/level/level = overmap_objects[id]
-		if(zlevel in level.linked_levels)
-			return level
+		if(istype(overmap_objects[id], /obj/structure/overmap/level))
+			var/obj/structure/overmap/level/L = overmap_objects[id]
+			if(zlevel in L.linked_levels)
+				return L
+		if(istype(overmap_objects[id], /obj/structure/overmap/dynamic))
+			var/obj/structure/overmap/dynamic/D = overmap_objects[id]
+			if(zlevel == D.virtual_z_level)
+				return D
 
 /datum/controller/subsystem/overmap/Recover()
 	if(istype(SSovermap.simulated_ships))

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -340,7 +340,10 @@ SUBSYSTEM_DEF(overmap)
 		ruin_type.load(ruin_turf)
 
 	if(mapgen) //Does AFTER the ruin is loaded so that it does not spawn flora/fauna in the ruin
-		mapgen.generate_terrain(encounter_reservation.area_type.contents)
+		var/list/turfs = list()
+		for(var/turf/T in encounter_reservation.area_type.contents)
+			turfs += T
+		mapgen.generate_terrain(turfs)
 
 	//gets the turf with an X in the middle of the reservation, and a Y that's 1/4ths up in the reservation.
 	var/turf/docking_turf = locate(encounter_reservation.bottom_left_coords[1] + dock_size, encounter_reservation.bottom_left_coords[2] + FLOOR(dock_size / 2, 1), encounter_reservation.bottom_left_coords[3])

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -97,7 +97,7 @@ SUBSYSTEM_DEF(overmap)
   * * Shuttle: The docking port to create an overmap object for
   */
 /datum/controller/subsystem/overmap/proc/setup_shuttle_ship(obj/docking_port/mobile/shuttle)
-	var/docked_object = get_overmap_object_by_z(get_virtual_z_level(shuttle))
+	var/docked_object = get_overmap_object_by_z(shuttle.get_virtual_z_level())
 	if(docked_object)
 		shuttle.current_ship = new /obj/structure/overmap/ship/simulated(docked_object, shuttle.id, shuttle)
 		if(shuttle.undock_roundstart)

--- a/whitesands/code/controllers/subsystem/overmap.dm
+++ b/whitesands/code/controllers/subsystem/overmap.dm
@@ -341,7 +341,7 @@ SUBSYSTEM_DEF(overmap)
 
 	if(mapgen) //Does AFTER the ruin is loaded so that it does not spawn flora/fauna in the ruin
 		var/list/turfs = list()
-		for(var/turf/T in encounter_reservation.area_type.contents)
+		for(var/turf/T in encounter_reservation.area_type)
 			turfs += T
 		mapgen.generate_terrain(turfs)
 

--- a/whitesands/code/game/area/areas/ruins/space.dm
+++ b/whitesands/code/game/area/areas/ruins/space.dm
@@ -1,24 +1,3 @@
-//DYNAMIC OVERMAP
-/area/space
-
-/area/ruin/unpowered/planetoid
-	name = "Unknown Planetoid"
-	icon_state = "away"
-	outdoors = TRUE
-	area_flags = UNIQUE_AREA | CAVES_ALLOWED | FLORA_ALLOWED | MOB_SPAWN_ALLOWED | NOTELEPORT
-
-/area/ruin/unpowered/planetoid/lava
-	name = "Volcanic Planetoid"
-
-/area/ruin/unpowered/planetoid/ice
-	name = "Frozen Planetoid"
-
-/area/ruin/unpowered/planetoid/sand
-	name = "Sandy Planetoid"
-
-/area/ruin/unpowered/planetoid/jungle
-	name = "Jungle Planetoid"
-
 //MACSPACE
 /area/ruin/space/has_grav/powered/macspace
 	name = "Mac Space Restaurant"

--- a/whitesands/code/game/objects/items/blueprints.dm
+++ b/whitesands/code/game/objects/items/blueprints.dm
@@ -129,6 +129,10 @@
 
 	target_shuttle.shuttle_areas[newA] = TRUE
 
+	newA.connect_to_shuttle(target_shuttle, target_shuttle.get_docked())
+	for(var/atom/thing in newA)
+		thing.connect_to_shuttle(target_shuttle, target_shuttle.get_docked())
+
 	target_shuttle.recalculate_bounds()
 
 	to_chat(creator, "<span class='notice'>You have created a new area, named [newA.name]. It is now weather proof, and constructing an APC will allow it to be powered.</span>")

--- a/whitesands/code/modules/overmap/ships/simulated.dm
+++ b/whitesands/code/modules/overmap/ships/simulated.dm
@@ -209,7 +209,7 @@
   * Proc called after a shuttle is moved, used for checking a ship's location when it's moved manually (E.G. calling the mining shuttle via a console)
   */
 /obj/structure/overmap/ship/simulated/proc/check_loc()
-	var/docked_object = SSovermap.get_overmap_object_by_z(shuttle.z)
+	var/docked_object = SSovermap.get_overmap_object_by_z(get_virtual_z_level(shuttle))
 	var/obj/docking_port/stationary/dock_port = shuttle.get_docked()
 	if(docked_object == loc) //The docked object is correct, move along
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Base code ported from Beestation/Beestation-Hornet#4202, but modified to fit our needs

## Why It's Good For The Game
Allows for planets/transit levels to truly feel separate from one another.

## Changelog
:cl:
add: Virtual z-levels
tweak: Each ~~shuttle~~ turf reservation will be treated as a different z-level, meaning things that affect a z-level (Comms, suit sensors, AI upload, explosions, etc.) will no longer be able to track different shuttles while they are in transit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
