### PR TITLE
Tweaks constructed item pre-filling, salvage ship autolathe no longer hacked by default.

### DIFF
--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -104,7 +104,7 @@
 /turf/open/floor/plating,
 /area/shuttle/mining/ship/cargo)
 "ci" = (
-/obj/machinery/autolathe/hacked,
+/obj/machinery/autolathe,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/shuttle/mining/ship/cargo)

--- a/_maps/shuttles/mining_ship_all.dmm
+++ b/_maps/shuttles/mining_ship_all.dmm
@@ -1875,6 +1875,9 @@
 /obj/structure/cable,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
+/obj/item/reagent_containers/glass/beaker{
+	list_reagents = list(/datum/reagent/fuel = 50)
+	},
 /turf/open/floor/plating,
 /area/shuttle/mining/ship/engine)
 "Ue" = (

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -25,6 +25,10 @@
 	var/power = 5 //Maximum distance launched water will travel
 	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row
 	var/cooling_power = 2 //Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled
+	var/start_full = TRUE
+
+/obj/item/extinguisher/empty
+	start_full = FALSE
 
 /obj/item/extinguisher/mini
 	name = "pocket fire extinguisher"
@@ -41,15 +45,19 @@
 	sprite_name = "miniFE"
 	dog_fashion = null
 
+/obj/item/extinguisher/mini/empty
+	start_full = FALSE
+
 /obj/item/extinguisher/proc/refill()
-	if(!chem)
-		return
 	create_reagents(max_water, AMOUNT_VISIBLE)
 	reagents.add_reagent(chem, max_water)
 
 /obj/item/extinguisher/Initialize()
 	. = ..()
-	refill()
+	if(start_full)
+		refill()
+	else
+		create_reagents(max_water, AMOUNT_VISIBLE)
 
 /obj/item/extinguisher/advanced
 	name = "advanced fire extinguisher"

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -32,13 +32,13 @@
 	///Whether the welding tool is on or off.
 	var/welding = FALSE
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
-	var/start_full = TRUE
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
 	var/change_icons = 1
 	var/can_off_process = 0
 	var/burned_fuel_for = 0	//when fuel was last removed
 	var/acti_sound = 'sound/items/welderactivate.ogg'
 	var/deac_sound = 'sound/items/welderdeactivate.ogg'
+	var/start_full = TRUE
 
 /obj/item/weldingtool/empty
 	start_full = FALSE

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -1,7 +1,7 @@
 #define WELDER_FUEL_BURN_INTERVAL 13
 /obj/item/weldingtool
 	name = "welding tool"
-	desc = "A standard edition welder provided by Nanotrasen."
+	desc = "A standard welder, used for cutting through metal."
 	icon = 'whitesands/icons/obj/tools.dmi' //WS Edit - Better Tool Sprites
 	icon_state = "welder"
 	item_state = "welder"
@@ -32,6 +32,7 @@
 	///Whether the welding tool is on or off.
 	var/welding = FALSE
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
+	var/start_full = TRUE
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
 	var/change_icons = 1
 	var/can_off_process = 0
@@ -39,10 +40,14 @@
 	var/acti_sound = 'sound/items/welderactivate.ogg'
 	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 
+/obj/item/weldingtool/empty
+	start_full = FALSE
+
 /obj/item/weldingtool/Initialize()
 	. = ..()
 	create_reagents(max_fuel)
-	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
+	if(start_full)
+		reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 	update_icon()
 
 /obj/item/weldingtool/ComponentInitialize()
@@ -303,15 +308,27 @@
 	else
 		return ""
 
+/obj/item/weldingtool/mini
+	name = "emergency welding tool"
+	desc = "A miniature welder used during emergencies."
+	icon_state = "miniwelder"
+	max_fuel = 10
+	w_class = WEIGHT_CLASS_TINY
+	custom_materials = list(/datum/material/iron=30, /datum/material/glass=10)
+	change_icons = 0
+
+/obj/item/weldingtool/mini/empty
+	start_full = FALSE
+
 /obj/item/weldingtool/largetank
 	name = "industrial welding tool"
 	desc = "A slightly larger welder with a larger tank."
 	icon_state = "indwelder"
 	max_fuel = 40
-	custom_materials = list(/datum/material/glass=60)
+	custom_materials = list(/datum/material/iron = 70, /datum/material/glass=60)
 
-/obj/item/weldingtool/largetank/flamethrower_screwdriver()
-	return
+/obj/item/weldingtool/largetank/empty
+	start_full = FALSE
 
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
@@ -324,19 +341,6 @@
 	if(!isOn())
 		return
 	switched_on(user)
-
-
-/obj/item/weldingtool/mini
-	name = "emergency welding tool"
-	desc = "A miniature welder used during emergencies."
-	icon_state = "miniwelder"
-	max_fuel = 10
-	w_class = WEIGHT_CLASS_TINY
-	custom_materials = list(/datum/material/iron=30, /datum/material/glass=10)
-	change_icons = 0
-
-/obj/item/weldingtool/mini/flamethrower_screwdriver()
-	return
 
 /obj/item/weldingtool/abductor
 	name = "alien welding tool"
@@ -360,6 +364,9 @@
 	item_state = "upindwelder"
 	max_fuel = 80
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
+
+/obj/item/weldingtool/hugetank/empty
+	start_full = FALSE
 
 /obj/item/weldingtool/experimental
 	name = "experimental welding tool"

--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -31,6 +31,7 @@
 	name = "improvised shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/improvised
 	max_ammo = 1
+	start_empty = TRUE
 
 /obj/item/ammo_box/magazine/internal/shot/riot
 	name = "riot shotgun internal magazine"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -51,7 +51,7 @@
 	id = "extinguisher"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 90)
-	build_path = /obj/item/extinguisher
+	build_path = /obj/item/extinguisher/empty
 	category = list("initial","Tools")
 
 /datum/design/pocketfireextinguisher
@@ -59,7 +59,7 @@
 	id = "pocketfireextinguisher"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 40)
-	build_path = /obj/item/extinguisher/mini
+	build_path = /obj/item/extinguisher/mini/empty
 	category = list("initial","Tools")
 
 /datum/design/multitool
@@ -89,22 +89,22 @@
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
-/datum/design/weldingtool
-	name = "Welding Tool"
-	id = "welding_tool"
-	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 70, /datum/material/glass = 20)
-	build_path = /obj/item/weldingtool
-	category = list("initial","Tools","Tool Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
-
 /datum/design/mini_weldingtool
 	name = "Emergency Welding Tool"
 	id = "mini_welding_tool"
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 30, /datum/material/glass = 10)
-	build_path = /obj/item/weldingtool/mini
+	build_path = /obj/item/weldingtool/mini/empty
 	category = list("initial","Tools")
+
+/datum/design/weldingtool
+	name = "Welding Tool"
+	id = "welding_tool"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 70, /datum/material/glass = 30)
+	build_path = /obj/item/weldingtool/empty
+	category = list("initial","Tools","Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/screwdriver
 	name = "Screwdriver"
@@ -778,14 +778,6 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2500)
 	build_path = /obj/item/electropack
-	category = list("hacked", "Tools")
-
-/datum/design/large_welding_tool
-	name = "Industrial Welding Tool"
-	id = "large_welding_tool"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 70, /datum/material/glass = 60)
-	build_path = /obj/item/weldingtool/largetank
 	category = list("hacked", "Tools")
 
 /datum/design/handcuffs

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -3,6 +3,15 @@
 /////////////////Tools///////////////////
 /////////////////////////////////////////
 
+/datum/design/large_welding_tool
+	name = "Industrial Welding Tool"
+	id = "large_welding_tool"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 70, /datum/material/glass = 60)
+	build_path = /obj/item/weldingtool/largetank/empty
+	category = list("initial", "Tool Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+
 /datum/design/handdrill
 	name = "Hand Drill"
 	desc = "A small electric hand drill with an interchangeable screwdriver and bolt bit"


### PR DESCRIPTION
## About The Pull Request

Stops fire extinguishers / welding tools constructed by the autolathe from spawning in filled with reagents. Stops the autolathe on the salvage ship from spawning in already hacked. Stops improvised shotguns from spawning in with a shell.

## Why It's Good For The Game

things appearing from thin air is bad, and hacking something is cooler than it spawning already hacked

## Changelog
:cl:
tweak: Autolathe-constructed welding tools + fire extinguishers no longer start filled.
tweak: The salvage ship's autolathe is no longer hacked by default.
tweak: Improvised shotgun no longer starts with ammo.
/:cl: