### PR TITLE
Configurable Smuggler Satchel Amounts

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -368,7 +368,7 @@
 	min_val = 0
 
 /datum/config_entry/number/smuggler_satchels
-	config_entry_value = 5
+	config_entry_value = 3
 	min_val = 0
 
 /datum/config_entry/number/bombcap

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -367,6 +367,10 @@
 	config_entry_value = 10
 	min_val = 0
 
+/datum/config_entry/number/smuggler_satchels
+	config_entry_value = 5
+	min_val = 0
+
 /datum/config_entry/number/bombcap
 	config_entry_value = 14
 	min_val = 4

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(minor_mapping)
 			num_mice -= 1
 			M = null
 
-/datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=5)
+/datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=3)
 	var/list/turfs = find_satchel_suitable_turfs()
 
 	while(turfs.len && amount > 0)

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -5,7 +5,7 @@ SUBSYSTEM_DEF(minor_mapping)
 
 /datum/controller/subsystem/minor_mapping/Initialize(timeofday)
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
-	place_satchels()
+	place_satchels(CONFIG_GET(number/smuggler_satchels))
 	return ..()
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(minor_mapping)
 			num_mice -= 1
 			M = null
 
-/datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
+/datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=5)
 	var/list/turfs = find_satchel_suitable_turfs()
 
 	while(turfs.len && amount > 0)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -559,7 +559,7 @@ MICE_ROUNDSTART 10
 
 ## How many smuggler's satchels you want to spawn under tiles roundstart. You may wish to set this lower on smaller maps.
 
-SMUGGLER_SATCHELS 5
+SMUGGLER_SATCHELS 3
 
 ## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -557,6 +557,10 @@ ARRIVALS_SHUTTLE_DOCK_WINDOW 55
 
 MICE_ROUNDSTART 10
 
+## How many smuggler's satchels you want to spawn under tiles roundstart. You may wish to set this lower on smaller maps.
+
+SMUGGLER_SATCHELS 5
+
 ## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
 


### PR DESCRIPTION

## Changelog
:cl:
add: Conf option for setting the amount of smuggler satchels that spawn roundstart
tweak: Only five satchels will try to spawn roundstart by default (as opposed to 10)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
