### PR TITLE
fixes rocks on jungle planet leading to space

### DIFF
--- a/code/datums/mapgen/biomes/_biome.dm
+++ b/code/datums/mapgen/biomes/_biome.dm
@@ -1,7 +1,7 @@
 ///This datum handles the transitioning from a turf to a specific biome, and handles spawning decorative structures and mobs.
 /datum/biome
 	///Type of turf this biome creates
-	var/turf_type
+	var/turf/turf_type
 	///Chance of having a structure from the flora types list spawn
 	var/flora_density = 0
 	///Chance of having a mob from the fauna types list spawn
@@ -13,7 +13,7 @@
 
 ///This proc handles the creation of a turf of a specific biome type
 /datum/biome/proc/generate_turf(var/turf/gen_turf)
-	gen_turf.ChangeTurf(turf_type, null, CHANGETURF_DEFER_CHANGE)
+	gen_turf.ChangeTurf(turf_type, initial(turf_type.baseturfs), CHANGETURF_DEFER_CHANGE)
 	if(length(fauna_types) && prob(fauna_density))
 		var/mob/fauna = pick(fauna_types)
 		new fauna(gen_turf)

--- a/code/game/turfs/open/floor/plating/planet.dm
+++ b/code/game/turfs/open/floor/plating/planet.dm
@@ -49,7 +49,8 @@
 	smooth_icon = 'icons/turf/floors/junglegrass.dmi'
 
 /turf/closed/mineral/random/jungle
+	turf_type = /turf/open/floor/plating/grass/jungle
+	baseturfs = /turf/open/floor/plating/grass/jungle
 	mineralSpawnChanceList = list(/obj/item/stack/ore/uranium = 5, /obj/item/stack/ore/diamond = 1, /obj/item/stack/ore/gold = 10,
 		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
 		/obj/item/stack/ore/bluespace_crystal = 1)
-	turf_type = /turf/open/floor/plating/dirt/jungle


### PR DESCRIPTION
## About The Pull Request

when you broke a rock wall on a jungle planet the turf left behind was space. this fixes that

## Why It's Good For The Game

it's a planet. not space

## Changelog
:cl:
fix: breaking jungle planet rocks no longer leads you to space
/:cl:
